### PR TITLE
Emit CORS headers to support web client integration. Closes #12

### DIFF
--- a/lib/adit_api/endpoint.ex
+++ b/lib/adit_api/endpoint.ex
@@ -36,5 +36,7 @@ defmodule AditApi.Endpoint do
     key: "_adit_api_key",
     signing_salt: "NAa/cp49"
 
+  plug CORSPlug
+
   plug AditApi.Router
 end

--- a/mix.exs
+++ b/mix.exs
@@ -37,6 +37,7 @@ defmodule AditApi.Mixfile do
      {:gettext, "~> 0.11"},
      {:cowboy, "~> 1.0"},
      {:httpoison, "~> 0.10.0"},
+     {:cors_plug, "~> 1.1"},
      {:distillery, "~> 1.0"}]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,6 @@
 %{"certifi": {:hex, :certifi, "0.7.0", "861a57f3808f7eb0c2d1802afeaae0fa5de813b0df0979153cbafcd853ababaf", [:rebar3], []},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
+  "cors_plug": {:hex, :cors_plug, "1.1.4", "b4c2f0de641700cd3168b90223d12dd5a3e9c54804c0c2451abe1b292620b375", [:mix], [{:cowboy, "~> 1.0.0", [hex: :cowboy, optional: false]}, {:plug, "> 0.8.0", [hex: :plug, optional: false]}]},
   "cowboy": {:hex, :cowboy, "1.0.4", "a324a8df9f2316c833a470d918aaf73ae894278b8aa6226ce7a9bf699388f878", [:rebar, :make], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], []},
   "db_connection": {:hex, :db_connection, "1.1.0", "b2b88db6d7d12f99997b584d09fad98e560b817a20dab6a526830e339f54cdb3", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, optional: true]}]},


### PR DESCRIPTION
Just standard (wide-open) config: accept origin '*' - can tune as needed